### PR TITLE
Specify chai version to avoid dependency issues, more verbose intervals, fix refresh bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/Rise-Vision/widget-web-page",
   "devDependencies": {
+    "chai": "~1.9.2",
     "chai-as-promised": "~4.1.1",
     "gulp": "~3.8.3",
     "gulp-bump": "~0.1.8",

--- a/src/settings.html
+++ b/src/settings.html
@@ -133,10 +133,11 @@
                 <div class="col-xs-6 col-md-3">
                   <select id="refresh" name="refresh" ng-model="settings.additionalParams.refresh" class="form-control">
                     <option value="0" selected="selected">{{"web-page.refresh.none" | translate}}</option>
-                    <option value="60000">1</option>
-                    <option value="300000">5</option>
-                    <option value="1800000">30</option>
-                    <option value="3600000">60</option>
+                    <option value="5000">5 Seconds</option>
+                    <option value="60000">1 Minute</option>
+                    <option value="300000">5 Minutes</option>
+                    <option value="1800000">30 Minutes</option>
+                    <option value="3600000">60 Minutes</option>
                   </select>
                 </div>
               </div>

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -83,7 +83,7 @@ RiseVision.WebPage = (function (document, gadgets) {
         container.style.visibility = "visible";
 
         // Run setInterval to reload page based on the data refresh value
-        if (_additionalParams.refresh > 0) {
+        if (_additionalParams.refresh > 0 && _intervalId === null) {
           _intervalId = setInterval(function () {
             _loadFrame();
           }, _additionalParams.refresh);


### PR DESCRIPTION
I don't know if this is a universal problem, but on Ubuntu 14.04 the npm install failed due to chai dependency issues. I updated the package.json to specify a version that satisfied all the dependencies. I also added a 5 second refresh option. Finally, there is a bug in the refresh logic where the setInterval kept recursively refreshing the target page. So the the second interval it was refreshed twice, the third interval refreshed three times, etc. 