### PR TITLE
Feature/reject preview urls

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.10",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.2.2",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.3.7"
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v2.5.12"
   },
   "resolutions": {
     "angular": "~1.3.0",

--- a/src/settings.html
+++ b/src/settings.html
@@ -48,7 +48,7 @@
             <div class="form-group">
               <url-field id="pageUrl" name="pageUrl" url="settings.additionalParams.url" hide-storage="hide"
                          ng-model="urlentry" valid url-input init-empty></url-field>
-              <p ng-if="!noXFrameOptions" class="text-danger">{{ "widget-web-page.warning.message" | translate }} <a ng-href="https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options" target="_blank">{{ "widget-web-page.warning.anchor" | translate}}</a>.</p>
+              <p ng-if="!noXFrameOptions" class="text-danger">{{ "widget-web-page.warning.xframe.message" | translate }} <a ng-href="https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options" target="_blank">{{ "widget-web-page.warning.xframe.anchor" | translate}}</a>.</p>
             </div>
 
             <!-- Refresh -->

--- a/src/settings.html
+++ b/src/settings.html
@@ -49,6 +49,9 @@
               <url-field id="pageUrl" name="pageUrl" url="settings.additionalParams.url" hide-storage="hide"
                          ng-model="urlentry" valid url-input init-empty></url-field>
               <p ng-if="!noXFrameOptions" class="text-danger">{{ "widget-web-page.warning.xframe.message" | translate }} <a ng-href="https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options" target="_blank">{{ "widget-web-page.warning.xframe.anchor" | translate}}</a>.</p>
+              <p ng-if="isPreviewUrl" class="text-danger">
+                {{ "widget-web-page.warning.preview" | translate }}
+              </p>
             </div>
 
             <!-- Refresh -->

--- a/src/settings/ctr-web-page-settings.js
+++ b/src/settings/ctr-web-page-settings.js
@@ -25,6 +25,8 @@ angular.module( "risevision.widget.web-page.settings" )
       } );
 
       $scope.$watch( "settings.additionalParams.url", function( newVal, oldVal ) {
+        $scope.isPreviewUrl = newVal && newVal.indexOf( "preview.risevision.com" ) > 0;
+
         if ( typeof oldVal === "undefined" && newVal && newVal !== "" ) {
           $scope.urlInput = true;
 
@@ -40,7 +42,6 @@ angular.module( "risevision.widget.web-page.settings" )
             }
           }
         }
-
       } );
 
       $scope.$watch( "settings.additionalParams.zoom", function( value ) {

--- a/src/settings/ctr-web-page-settings.js
+++ b/src/settings/ctr-web-page-settings.js
@@ -3,6 +3,7 @@ angular.module( "risevision.widget.web-page.settings" )
     function( $scope, $log, xframeOptions ) {
 
       $scope.noXFrameOptions = true;
+      $scope.isPreviewUrl = false;
       $scope.urlInput = false;
 
       $scope.validateXFrame = function() {

--- a/test/unit/settings/settings-spec.js
+++ b/test/unit/settings/settings-spec.js
@@ -28,4 +28,39 @@ describe( "Web Page Settings", function() {
     expect( $scope.initialView ).to.be.truely;
   } );
 
+  describe( "isPreviewUrl", function() {
+
+    beforeEach( function() {
+      $scope.settingsForm = {
+        pageUrl: {
+          $setValidity: function() {
+            return;
+          }
+        }
+      };
+    } );
+
+    it( "should set isPreviewUrl to true if the selected URL contains preview.risevision.com", function() {
+      expect( $scope.isPreviewUrl ).to.be.false;
+
+      $scope.settings = defaultSettings;
+      $scope.settings.additionalParams.url = "http://preview.risevision.com/x";
+
+      $scope.$digest();
+
+      expect( $scope.isPreviewUrl ).to.be.true;
+    } );
+
+    it( "should set isPreviewUrl to false if the selected URL does not contain preview.risevision.com", function() {
+      expect( $scope.isPreviewUrl ).to.be.false;
+
+      $scope.settings = defaultSettings;
+      $scope.settings.additionalParams.url = "http://postview.risevision.com/x";
+
+      $scope.$digest();
+
+      expect( $scope.isPreviewUrl ).to.be.false;
+    } );
+  } );
+
 } );


### PR DESCRIPTION
This presents an error message if the URL contains 'preview.risevision.com'. Saving is still allowed even if the message appears.

Manually tested, presentation using staged version:

https://apps.risevision.com/editor/workspace/5dcd5dff-94a4-4b6f-95de-52e14e05354a/?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013