### PR TITLE
Fix/fixes issue 88

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,8 +153,19 @@
       "test/unit/settings/**/*spec.js"]}
   ));
 
+  gulp.task("test:unit:widget", factory.testUnitAngular(
+    {testFiles: [
+      "node_modules/widget-tester/mocks/gadget-mocks.js",
+      "node_modules/widget-tester/mocks/logger-mock.js",
+      "src/components/widget-common/dist/config.js",
+      "src/config/test.js",
+      "src/widget/webpage.js",
+      "test/unit/widget/*spec.js"
+    ]}
+  ));
+
   gulp.task("test:unit", (cb) => {
-    runSequence("test:unit:settings", cb);
+    runSequence("test:unit:widget", "test:unit:settings", cb);
   });
 
   // ***** Integration Testing ***** //

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -236,7 +236,10 @@ RiseVision.WebPage = ( function( document, gadgets ) {
   }
 
   function withCacheBusterAppended( url ) {
-    return url;
+    var separator = /[?&]/.test( url ) ? "&" : "?",
+      timestamp = ( new Date() ).getTime();
+
+    return url + separator + "__cachebuster__=" + timestamp;
   }
 
   return {

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -157,9 +157,10 @@ RiseVision.WebPage = ( function( document, gadgets ) {
   function _loadFrame() {
     var container = document.getElementById( "container" ),
       fragment = document.createDocumentFragment(),
-      frame = _getFrameElement();
+      frame = _getFrameElement(),
+      refreshUrl = _url;
 
-    frame.setAttribute( "src", _url );
+    frame.setAttribute( "src", refreshUrl );
 
     fragment.appendChild( frame );
     container.appendChild( fragment );

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -158,7 +158,7 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     var container = document.getElementById( "container" ),
       fragment = document.createDocumentFragment(),
       frame = _getFrameElement(),
-      refreshUrl = _url;
+      refreshUrl = _additionalParams.refresh > 0 ? withCacheBuster( _url ) : _url;
 
     frame.setAttribute( "src", refreshUrl );
 
@@ -235,7 +235,7 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     _init();
   }
 
-  function withCacheBusterAppended( url ) {
+  function withCacheBuster( url ) {
     var hashIndex = url.indexOf( "#" ),
       fragments = hashIndex < 0 ? [ url, "" ] : [
         url.substring( 0, hashIndex ), url.substring( hashIndex )
@@ -253,7 +253,7 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     "pause": pause,
     "play": play,
     "stop": stop,
-    "withCacheBusterAppended": withCacheBusterAppended
+    "withCacheBuster": withCacheBuster
   };
 
 } )( document, gadgets );

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -236,10 +236,14 @@ RiseVision.WebPage = ( function( document, gadgets ) {
   }
 
   function withCacheBusterAppended( url ) {
-    var separator = /[?&]/.test( url ) ? "&" : "?",
+    var hashIndex = url.indexOf( "#" ),
+      fragments = hashIndex < 0 ? [ url, "" ] : [
+        url.substring( 0, hashIndex ), url.substring( hashIndex )
+      ],
+      separator = /[?&]/.test( fragments[ 0 ] ) ? "&" : "?",
       timestamp = ( new Date() ).getTime();
 
-    return url + separator + "__cachebuster__=" + timestamp;
+    return fragments[ 0 ] + separator + "__cachebuster__=" + timestamp + fragments[ 1 ];
   }
 
   return {

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -235,13 +235,18 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     _init();
   }
 
+  function withCacheBusterAppended( url ) {
+    return url;
+  }
+
   return {
     "getTableName": getTableName,
     "logEvent": logEvent,
     "setAdditionalParams": setAdditionalParams,
     "pause": pause,
     "play": play,
-    "stop": stop
+    "stop": stop,
+    "withCacheBusterAppended": withCacheBusterAppended
   };
 
 } )( document, gadgets );

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -158,7 +158,8 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     var container = document.getElementById( "container" ),
       fragment = document.createDocumentFragment(),
       frame = _getFrameElement(),
-      refreshUrl = _additionalParams.refresh > 0 ? withCacheBuster( _url ) : _url;
+      refreshUrl = _additionalParams.refresh > 0 && !_initialLoad ?
+        withCacheBuster( _url ) : _url;
 
     frame.setAttribute( "src", refreshUrl );
 

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -113,7 +113,7 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     _intervalId = setInterval( function() {
       _utils.hasInternetConnection( "img/transparent.png", function( hasInternet ) {
         if ( hasInternet ) {
-          _loadFrame();
+          _loadFrame( true );
         }
       } );
     }, _additionalParams.refresh );
@@ -154,12 +154,11 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     return frame;
   }
 
-  function _loadFrame() {
+  function _loadFrame( isRefresh ) {
     var container = document.getElementById( "container" ),
       fragment = document.createDocumentFragment(),
       frame = _getFrameElement(),
-      refreshUrl = _additionalParams.refresh > 0 && !_initialLoad ?
-        withCacheBuster( _url ) : _url;
+      refreshUrl = isRefresh ? withCacheBuster( _url ) : _url;
 
     frame.setAttribute( "src", refreshUrl );
 
@@ -222,7 +221,7 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     logEvent( { "event": "play", "url": _url } );
 
     if ( _initialLoad || _additionalParams.unload ) {
-      _loadFrame();
+      _loadFrame( false );
     }
   }
 

--- a/test/integration/webpage-refresh.html
+++ b/test/integration/webpage-refresh.html
@@ -103,7 +103,9 @@
     });
 
     test("should set src attribute with url value", function () {
-      assert.equal(tempFrame.getAttribute("src"), "http://www.risevision.com");
+      var regex = /http:[/][/]www[.]risevision[.]com[?]__cachebuster__=\d+/;
+
+      assert.match(tempFrame.getAttribute("src"), regex);
     });
 
     test("should show second iframe", function(done) {

--- a/test/unit/widget/cache-buster-spec.js
+++ b/test/unit/widget/cache-buster-spec.js
@@ -9,7 +9,7 @@ describe( "withCacheBusterAppended()", function() {
 
   it( "should append a cache buster parameter to an URL with no query string", function() {
     var url = "http://localhost:8080/",
-      regex = /http:[/][/]localhost:8080[/]/;
+      regex = /http:[/][/]localhost:8080[/][?]__cachebuster__=\d+/;
 
     expect( page.withCacheBusterAppended( url ) ).to.match( regex );
   } );

--- a/test/unit/widget/cache-buster-spec.js
+++ b/test/unit/widget/cache-buster-spec.js
@@ -1,0 +1,16 @@
+/* global describe, it, expect, RiseVision */
+
+/* eslint-disable func-names */
+
+"use strict";
+
+describe( "withCacheBusterAppended()", function() {
+  var page = RiseVision.WebPage;
+
+  it( "should append a cache buster parameter to an URL with no query string", function() {
+    var url = "https://localhost:8080/";
+
+    expect( page.withCacheBusterAppended( url ) ).to.equal( url );
+  } );
+
+} );

--- a/test/unit/widget/cache-buster-spec.js
+++ b/test/unit/widget/cache-buster-spec.js
@@ -8,9 +8,9 @@ describe( "withCacheBusterAppended()", function() {
   var page = RiseVision.WebPage;
 
   it( "should append a cache buster parameter to an URL with no query string", function() {
-    var url = "https://localhost:8080/";
+    var url = "http://localhost:8080/";
 
-    expect( page.withCacheBusterAppended( url ) ).to.equal( url );
+    expect( page.withCacheBusterAppended( url ) ).to.match( /http:[/][/]localhost:8080[/]/ );
   } );
 
 } );

--- a/test/unit/widget/cache-buster-spec.js
+++ b/test/unit/widget/cache-buster-spec.js
@@ -8,9 +8,10 @@ describe( "withCacheBusterAppended()", function() {
   var page = RiseVision.WebPage;
 
   it( "should append a cache buster parameter to an URL with no query string", function() {
-    var url = "http://localhost:8080/";
+    var url = "http://localhost:8080/",
+      regex = /http:[/][/]localhost:8080[/]/;
 
-    expect( page.withCacheBusterAppended( url ) ).to.match( /http:[/][/]localhost:8080[/]/ );
+    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
   } );
 
 } );

--- a/test/unit/widget/cache-buster-spec.js
+++ b/test/unit/widget/cache-buster-spec.js
@@ -14,4 +14,11 @@ describe( "withCacheBusterAppended()", function() {
     expect( page.withCacheBusterAppended( url ) ).to.match( regex );
   } );
 
+  it( "should append a cache buster parameter to an URL that already has a query string", function() {
+    var url = "http://localhost:8080/?param=1&param=2",
+      regex = /http:[/][/]localhost:8080[/][?]param=1&param=2&__cachebuster__=\d+/;
+
+    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+  } );
+
 } );

--- a/test/unit/widget/cache-buster-spec.js
+++ b/test/unit/widget/cache-buster-spec.js
@@ -4,49 +4,49 @@
 
 "use strict";
 
-describe( "withCacheBusterAppended()", function() {
+describe( "withCacheBuster()", function() {
   var page = RiseVision.WebPage;
 
   it( "should append a cache buster parameter to an URL with no query string", function() {
     var url = "http://localhost:8080/",
       regex = /http:[/][/]localhost:8080[/][?]__cachebuster__=\d+/;
 
-    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+    expect( page.withCacheBuster( url ) ).to.match( regex );
   } );
 
   it( "should append a cache buster parameter to an URL that already has a query string", function() {
     var url = "http://localhost:8080/?param=1&param=2",
       regex = /http:[/][/]localhost:8080[/][?]param=1&param=2&__cachebuster__=\d+/;
 
-    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+    expect( page.withCacheBuster( url ) ).to.match( regex );
   } );
 
   it( "should append a cache buster parameter to an URL with no query string and hash", function() {
     var url = "http://localhost:8080/#anchor",
       regex = /http:[/][/]localhost:8080[/][?]__cachebuster__=\d+#anchor/;
 
-    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+    expect( page.withCacheBuster( url ) ).to.match( regex );
   } );
 
   it( "should append a cache buster parameter to an URL that already has a query string and hash", function() {
     var url = "http://localhost:8080/?param=1&param=2#anchor",
       regex = /http:[/][/]localhost:8080[/][?]param=1&param=2&__cachebuster__=\d+#anchor/;
 
-    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+    expect( page.withCacheBuster( url ) ).to.match( regex );
   } );
 
   it( "should append a cache buster parameter to an URL that has a hash with extra # characters", function() {
     var url = "http://localhost:8080/?param=1&param=2#anchor#other#",
       regex = /http:[/][/]localhost:8080[/][?]param=1&param=2&__cachebuster__=\d+#anchor#other#/;
 
-    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+    expect( page.withCacheBuster( url ) ).to.match( regex );
   } );
 
   it( "should append a cache buster parameter to an URL that has a hash with a false query string", function() {
     var url = "http://localhost:8080/#anchor?other=1",
       regex = /http:[/][/]localhost:8080[/][?]__cachebuster__=\d+#anchor[?]other=1/;
 
-    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+    expect( page.withCacheBuster( url ) ).to.match( regex );
   } );
 
 } );

--- a/test/unit/widget/cache-buster-spec.js
+++ b/test/unit/widget/cache-buster-spec.js
@@ -21,4 +21,32 @@ describe( "withCacheBusterAppended()", function() {
     expect( page.withCacheBusterAppended( url ) ).to.match( regex );
   } );
 
+  it( "should append a cache buster parameter to an URL with no query string and hash", function() {
+    var url = "http://localhost:8080/#anchor",
+      regex = /http:[/][/]localhost:8080[/][?]__cachebuster__=\d+#anchor/;
+
+    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+  } );
+
+  it( "should append a cache buster parameter to an URL that already has a query string and hash", function() {
+    var url = "http://localhost:8080/?param=1&param=2#anchor",
+      regex = /http:[/][/]localhost:8080[/][?]param=1&param=2&__cachebuster__=\d+#anchor/;
+
+    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+  } );
+
+  it( "should append a cache buster parameter to an URL that has a hash with extra # characters", function() {
+    var url = "http://localhost:8080/?param=1&param=2#anchor#other#",
+      regex = /http:[/][/]localhost:8080[/][?]param=1&param=2&__cachebuster__=\d+#anchor#other#/;
+
+    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+  } );
+
+  it( "should append a cache buster parameter to an URL that has a hash with a false query string", function() {
+    var url = "http://localhost:8080/#anchor?other=1",
+      regex = /http:[/][/]localhost:8080[/][?]__cachebuster__=\d+#anchor[?]other=1/;
+
+    expect( page.withCacheBusterAppended( url ) ).to.match( regex );
+  } );
+
 } );


### PR DESCRIPTION
I added a __cachebuster__ parameter with the current timestamp as value, only when there's a refresh value set.

I manually tested with a schedule pointing to a single or a double presentation similar to what the customer is doing, and it's working correctly.

I won't merge until Monday.
