### PR TITLE
Fix/remove extra periods

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.4.10",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.4.1",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
-    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.3.2"
+    "common-header": "https://github.com/Rise-Vision/common-header.git#v3.3.3"
   },
   "resolutions": {
     "angular": "~1.3.0",

--- a/src/settings.html
+++ b/src/settings.html
@@ -52,8 +52,8 @@
                 {{ "widget-web-page.warning.xframe.message" | translate }}
                 <a ng-if="!noXFrameOptions" target="_blank"
                   ng-href="https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options"
-                >{{ "widget-web-page.warning.xframe.anchor" | translate }}</a>.
-                <a ng-if="!noFrameAncestors" target="_blank"
+                >{{ "widget-web-page.warning.xframe.anchor" | translate }}</a
+                ><a ng-if="!noFrameAncestors" target="_blank"
                   ng-href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors"
                 >{{ "widget-web-page.warning.frameAncestors.anchor" | translate }}</a>.
               </p>


### PR DESCRIPTION
The common-header import removes one of the extra periods, and the other is removed from the settings page.

Fix here: https://apps.risevision.com/editor/workspace/87dadfa4-488c-4267-b080-bd61e4cb5ed4/?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

warnings appear with https://www.fireeye.com/cyber-map/threat-map.html and http://www.google.com
