### PR TITLE
Restrict url to use HTTPS

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -60,7 +60,7 @@
               <p ng-if="isPreviewUrl" class="text-danger">
                 {{ "widget-web-page.warning.preview" | translate }}
               </p>
-              <p ng-if="isInsecureUrl" class="text-danger">
+              <p ng-if="!isSecureUrl" class="text-danger">
                 Please use secure URLs (HTTPs). Insecure URLs (HTTP) aren't supported.
               </p>
             </div>

--- a/src/settings.html
+++ b/src/settings.html
@@ -60,6 +60,9 @@
               <p ng-if="isPreviewUrl" class="text-danger">
                 {{ "widget-web-page.warning.preview" | translate }}
               </p>
+              <p ng-if="isInsecureUrl" class="text-danger">
+                Please use secure URLs (HTTPs). Insecure URLs (HTTP) aren't supported.
+              </p>
             </div>
 
             <!-- Refresh -->

--- a/src/settings/ctr-web-page-settings.js
+++ b/src/settings/ctr-web-page-settings.js
@@ -5,11 +5,11 @@ angular.module( "risevision.widget.web-page.settings" )
       $scope.noFrameAncestors = true;
       $scope.noXFrameOptions = true;
       $scope.isPreviewUrl = false;
-      $scope.isInsecureUrl = false;
+      $scope.isSecureUrl = true;
       $scope.urlInput = false;
 
-      function isInsecureUrl( url ) {
-        return !!( url && url.startsWith( "http://" ) );
+      function isSecureUrl( url ) {
+        return !!( url && url.startsWith( "https://" ) );
       }
 
       function isMissingProtocol( url ) {
@@ -17,14 +17,14 @@ angular.module( "risevision.widget.web-page.settings" )
       }
 
       function processUrl() {
-        $scope.isInsecureUrl = isInsecureUrl( $scope.settings.additionalParams.url );
-
-        if ( $scope.isInsecureUrl ) {
-          return;
-        }
-
         if ( isMissingProtocol( $scope.settings.additionalParams.url ) ) {
           $scope.settings.additionalParams.url = "https://" + $scope.settings.additionalParams.url;
+        }
+
+        $scope.isSecureUrl = isSecureUrl( $scope.settings.additionalParams.url );
+
+        if ( !$scope.isSecureUrl ) {
+          return;
         }
 
         $scope.validateXFrame();
@@ -50,9 +50,9 @@ angular.module( "risevision.widget.web-page.settings" )
         }
       } );
 
-      $scope.$watch( "isInsecureUrl", function( value ) {
+      $scope.$watch( "isSecureUrl", function( value ) {
         if ( typeof value !== "undefined" ) {
-          $scope.settingsForm.pageUrl.$setValidity( "isInsecureUrl", !value );
+          $scope.settingsForm.pageUrl.$setValidity( "isSecureUrl", value );
         }
       } );
 
@@ -73,7 +73,7 @@ angular.module( "risevision.widget.web-page.settings" )
             // ensure warning messages don't get shown while url field is receiving input
             $scope.noFrameAncestors = true;
             $scope.noXFrameOptions = true;
-            $scope.isInsecureUrl = false;
+            $scope.isSecureUrl = true;
 
             if ( newVal !== "" ) {
               $scope.urlInput = true;

--- a/src/settings/ctr-web-page-settings.js
+++ b/src/settings/ctr-web-page-settings.js
@@ -5,7 +5,20 @@ angular.module( "risevision.widget.web-page.settings" )
       $scope.noFrameAncestors = true;
       $scope.noXFrameOptions = true;
       $scope.isPreviewUrl = false;
+      $scope.isInsecureUrl = false;
       $scope.urlInput = false;
+
+      function isInsecureUrl( url ) {
+        return !!( url && url.startsWith( "http://" ) );
+      }
+
+      function processUrl() {
+        $scope.isInsecureUrl = isInsecureUrl( $scope.settings.additionalParams.url );
+
+        if ( !$scope.isInsecureUrl ) {
+          $scope.validateXFrame();
+        }
+      }
 
       $scope.validateXFrame = function() {
         responseHeaderAnalyzer.getOptions( $scope.settings.additionalParams.url )
@@ -17,13 +30,19 @@ angular.module( "risevision.widget.web-page.settings" )
 
       $scope.$on( "urlFieldBlur", function() {
         if ( $scope.settingsForm.pageUrl.$valid ) {
-          $scope.validateXFrame();
+          processUrl();
         }
       } );
 
       $scope.$watch( "urlInput", function( value ) {
         if ( typeof value !== "undefined" ) {
           $scope.settingsForm.pageUrl.$setValidity( "urlInput", value );
+        }
+      } );
+
+      $scope.$watch( "isInsecureUrl", function( value ) {
+        if ( typeof value !== "undefined" ) {
+          $scope.settingsForm.pageUrl.$setValidity( "isInsecureUrl", !value );
         }
       } );
 
@@ -34,12 +53,13 @@ angular.module( "risevision.widget.web-page.settings" )
           $scope.urlInput = true;
 
           // previously saved settings are being shown, ensure to check if page has X-Frame-Options
-          $scope.validateXFrame();
+          processUrl();
         } else {
           if ( typeof newVal !== "undefined" ) {
             // ensure warning messages don't get shown while url field is receiving input
             $scope.noFrameAncestors = true;
             $scope.noXFrameOptions = true;
+            $scope.isInsecureUrl = false;
 
             if ( newVal !== "" ) {
               $scope.urlInput = true;

--- a/src/settings/ctr-web-page-settings.js
+++ b/src/settings/ctr-web-page-settings.js
@@ -12,12 +12,22 @@ angular.module( "risevision.widget.web-page.settings" )
         return !!( url && url.startsWith( "http://" ) );
       }
 
+      function isMissingProtocol( url ) {
+        return !!( url && url.indexOf( "://" ) === -1 );
+      }
+
       function processUrl() {
         $scope.isInsecureUrl = isInsecureUrl( $scope.settings.additionalParams.url );
 
-        if ( !$scope.isInsecureUrl ) {
-          $scope.validateXFrame();
+        if ( $scope.isInsecureUrl ) {
+          return;
         }
+
+        if ( isMissingProtocol( $scope.settings.additionalParams.url ) ) {
+          $scope.settings.additionalParams.url = "https://" + $scope.settings.additionalParams.url;
+        }
+
+        $scope.validateXFrame();
       }
 
       $scope.validateXFrame = function() {

--- a/src/settings/ctr-web-page-settings.js
+++ b/src/settings/ctr-web-page-settings.js
@@ -47,6 +47,10 @@ angular.module( "risevision.widget.web-page.settings" )
       } );
 
       $scope.$watch( "settings.additionalParams.url", function( newVal, oldVal ) {
+        var urlEl = angular.element( document.querySelector( "#pageUrl input[ name = 'url' ]" ) );
+
+        // override directive placeholder to display https://
+        urlEl.attr( "placeholder", "https://" );
         $scope.isPreviewUrl = newVal && newVal.indexOf( "preview.risevision.com" ) > 0;
 
         if ( typeof oldVal === "undefined" && newVal && newVal !== "" ) {

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -209,9 +209,9 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     // Configure the value for _url
     _url = _additionalParams.url;
 
-    // Add http:// if no protocol parameter exists
+    // Add https:// if no protocol parameter exists
     if ( _url.indexOf( "://" ) === -1 ) {
-      _url = "http://" + _url;
+      _url = "https://" + _url;
     }
 
     _logConfiguration();

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -209,9 +209,9 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     // Configure the value for _url
     _url = _additionalParams.url;
 
-    // Add https:// if no protocol parameter exists
+    // Add http:// if no protocol parameter exists
     if ( _url.indexOf( "://" ) === -1 ) {
-      _url = "https://" + _url;
+      _url = "http://" + _url;
     }
 
     _logConfiguration();

--- a/test/e2e/settings.js
+++ b/test/e2e/settings.js
@@ -15,7 +15,7 @@
   expect = chai.expect;
 
   describe( "Web Page Settings - e2e Testing", function() {
-    var validUrl = "http://www.valid-url.com",
+    var validUrl = "https://www.valid-url.com",
       invalidUrl = "http://w";
 
     beforeEach( function() {
@@ -165,7 +165,7 @@
 
     describe( "X-Frame-Options warning message", function() {
       it( "should not show warning when URL Field is receiving input", function() {
-        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://test" );
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "https://test" );
 
         expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.false;
       } );
@@ -179,7 +179,7 @@
       } );
 
       it( "should not show warning message when a webpage doesn't specify X-Frame-Options header", function() {
-        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://www.risevision.com" );
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "https://www.risevision.com" );
         // remove focus
         element( by.css( "h3.modal-title" ) ).click();
 
@@ -194,6 +194,30 @@
         element( by.css( "h3.modal-title" ) ).click();
 
         expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.true;
+      } );
+    } );
+
+    describe( "HTTP protocol error message", function() {
+      it( "should not show warning when URL Field is receiving input", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://test" );
+
+        expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.false;
+      } );
+
+      it( "should show warning message when user inputs webpage using HTTP protocol", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://www.risevision.com" );
+        // remove focus
+        element( by.css( "h3.modal-title" ) ).click();
+
+        expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.true;
+      } );
+
+      it( "should not show error message when user inputs webpage using HTTPS protocol", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "https://www.risevision.com" );
+        // remove focus
+        element( by.css( "h3.modal-title" ) ).click();
+
+        expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.false;
       } );
     } );
 

--- a/test/e2e/settings.js
+++ b/test/e2e/settings.js
@@ -249,6 +249,14 @@
         expect( element( by.model( "settings.additionalParams.zoom" ) ).getAttribute( "value" ) ).to.eventually.equal( "0.50" );
       } );
 
+      it( "Should prefix a url with https:// if protocol is missing", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "risevision.com" );
+        // remove focus
+        element( by.css( "h3.modal-title" ) ).click();
+
+        expect( element( by.css( "#pageUrl input[name='url']" ) ).getAttribute( "value" ) ).to.eventually.equal( "https://risevision.com" );
+      } );
+
       it( "Should correctly save settings", function() {
         var settings = {
           params: {},


### PR DESCRIPTION
## Description
Ensuring a url input with HTTP protocol in the Widget Settings shows a validation error message and "Save" button is disabled. 

This functionality is additional and handled separately from the `url-field` directive internal url validation logic.

## Motivation and Context
Stop propagating the use of HTTP protocol in URLs for content. We only support HTTPS. 

## How Has This Been Tested?
Tested locally and with stage version of widget in this presentation - https://apps.risevision.com/editor/workspace/872ac494-986b-49e0-b160-5920586ff5cd?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

** Need to manually change to use a HTTP url

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
