### PR TITLE
Log widget id

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "angular-bootstrap": "^0.13.0",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.57",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.11.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.4.1",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v3.3.3"

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -218,6 +218,10 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     _ready();
   }
 
+  function getWidgetId() {
+    return _utils.getQueryParameter( "up_id" );
+  }
+
   /*
    *  Public Methods
    */
@@ -226,7 +230,7 @@ RiseVision.WebPage = ( function( document, gadgets ) {
   }
 
   function logEvent( params ) {
-    RiseVision.Common.LoggerUtils.logEvent( getTableName(), params );
+    RiseVision.Common.LoggerUtils.logEvent( getTableName(), Object.assign( {}, params, { "widget_id": getWidgetId() } ) );
   }
 
   function pause() {

--- a/test/integration/logging.html
+++ b/test/integration/logging.html
@@ -26,8 +26,8 @@
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
 
-<script src="../../src/components/widget-common/dist/common.js"></script>
 <script src="../../src/components/widget-common/dist/config.js"></script>
+<script src="../../src/components/widget-common/dist/common.js"></script>
 <script src="../../src/widget/webpage.js"></script>
 <script src="../../src/components/widget-common/dist/message.js"></script>
 
@@ -55,11 +55,8 @@
       spy.restore();
     });
 
-    setup(function() {
-    });
-
     suite("configuration", function() {
-      test("should log the play event", function() {
+      test("should log the configuration event", function() {
         params.event = "configuration";
         params.event_details = JSON.stringify( window.gadget.settings.additionalParams );
         assert(spy.calledOnce);

--- a/test/integration/logging.html
+++ b/test/integration/logging.html
@@ -26,6 +26,7 @@
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
 
+<script src="../../src/components/widget-common/dist/common.js"></script>
 <script src="../../src/components/widget-common/dist/config.js"></script>
 <script src="../../src/widget/webpage.js"></script>
 <script src="../../src/components/widget-common/dist/message.js"></script>
@@ -46,7 +47,8 @@
       params = {
         "url": window.gadget.settings.additionalParams.url,
         "company_id": '"companyId"',
-        "display_id": '"displayId"'
+        "display_id": '"displayId"',
+        "widget_id": null
       };
 
     suiteTeardown(function() {

--- a/test/integration/messaging.html
+++ b/test/integration/messaging.html
@@ -27,6 +27,7 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
 
 <script src="../../src/components/widget-common/dist/config.js"></script>
+<script src="../../src/components/widget-common/dist/common.js"></script>
 <script src="../../src/widget/webpage.js"></script>
 <script src="../../src/components/widget-common/dist/message.js"></script>
 


### PR DESCRIPTION
## Description
Now includes widget id when logging to BQ

The only log the widget makes is `configuration` event.

Widget was updated to use latest widget-common release, so it now will also log `env` and `viewer_id` values, handled automatically by the Logger class from widget-common. 

## Motivation and Context
Help to identify users presentations where they have used a url with HTTP protocol. This was next best option after presentation id, which presentation id is not possible to obtain as its not provided when running on display or shared schedules. 

## How Has This Been Tested?
Staged a version of widget in this presentation and validated logs from ChrOS player. 

![image](https://user-images.githubusercontent.com/7407007/99713164-f846e980-2a71-11eb-9d27-042409dff394.png)

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
