### PR TITLE
Restrict HTTP and log widget id

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "angular-bootstrap": "^0.13.0",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.57",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#3.11.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.12.3",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.4.1",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v3.3.3"

--- a/src/settings.html
+++ b/src/settings.html
@@ -60,6 +60,9 @@
               <p ng-if="isPreviewUrl" class="text-danger">
                 {{ "widget-web-page.warning.preview" | translate }}
               </p>
+              <p ng-if="!isSecureUrl" class="text-danger">
+                Please use secure URLs (HTTPs). Insecure URLs (HTTP) aren't supported.
+              </p>
             </div>
 
             <!-- Refresh -->

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -66,6 +66,9 @@
     gadgets.rpc.call( "", "rsparam_get", null, id, [ "companyId", "displayId", "additionalParams" ] );
   }
 
+  // TODO: prevent HTTP
+  // TODO: log presentation id
+
 } )( window, document, gadgets );
 
 

--- a/src/widget/main.js
+++ b/src/widget/main.js
@@ -66,9 +66,6 @@
     gadgets.rpc.call( "", "rsparam_get", null, id, [ "companyId", "displayId", "additionalParams" ] );
   }
 
-  // TODO: prevent HTTP
-  // TODO: log presentation id
-
 } )( window, document, gadgets );
 
 

--- a/src/widget/webpage.js
+++ b/src/widget/webpage.js
@@ -218,6 +218,10 @@ RiseVision.WebPage = ( function( document, gadgets ) {
     _ready();
   }
 
+  function getWidgetId() {
+    return _utils.getQueryParameter( "up_id" );
+  }
+
   /*
    *  Public Methods
    */
@@ -226,7 +230,7 @@ RiseVision.WebPage = ( function( document, gadgets ) {
   }
 
   function logEvent( params ) {
-    RiseVision.Common.LoggerUtils.logEvent( getTableName(), params );
+    RiseVision.Common.LoggerUtils.logEvent( getTableName(), Object.assign( {}, params, { "widget_id": getWidgetId() } ) );
   }
 
   function pause() {

--- a/test/e2e/settings.js
+++ b/test/e2e/settings.js
@@ -15,7 +15,7 @@
   expect = chai.expect;
 
   describe( "Web Page Settings - e2e Testing", function() {
-    var validUrl = "http://www.valid-url.com",
+    var validUrl = "https://www.valid-url.com",
       invalidUrl = "http://w";
 
     beforeEach( function() {
@@ -165,7 +165,7 @@
 
     describe( "X-Frame-Options warning message", function() {
       it( "should not show warning when URL Field is receiving input", function() {
-        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://test" );
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "https://test" );
 
         expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.false;
       } );
@@ -179,7 +179,7 @@
       } );
 
       it( "should not show warning message when a webpage doesn't specify X-Frame-Options header", function() {
-        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://www.risevision.com" );
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "https://www.risevision.com" );
         // remove focus
         element( by.css( "h3.modal-title" ) ).click();
 
@@ -194,6 +194,30 @@
         element( by.css( "h3.modal-title" ) ).click();
 
         expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.true;
+      } );
+    } );
+
+    describe( "HTTP protocol error message", function() {
+      it( "should not show warning when URL Field is receiving input", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://test" );
+
+        expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.false;
+      } );
+
+      it( "should show warning message when user inputs webpage using HTTP protocol", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "http://www.risevision.com" );
+        // remove focus
+        element( by.css( "h3.modal-title" ) ).click();
+
+        expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.true;
+      } );
+
+      it( "should not show error message when user inputs webpage using HTTPS protocol", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "https://www.risevision.com" );
+        // remove focus
+        element( by.css( "h3.modal-title" ) ).click();
+
+        expect( element( by.css( "#pageUrl + p.text-danger" ) ).isPresent() ).to.eventually.be.false;
       } );
     } );
 
@@ -223,6 +247,14 @@
         element( by.cssContainingText( "option", "50%" ) ).click();
 
         expect( element( by.model( "settings.additionalParams.zoom" ) ).getAttribute( "value" ) ).to.eventually.equal( "0.50" );
+      } );
+
+      it( "Should prefix a url with https:// if protocol is missing", function() {
+        element( by.css( "#pageUrl input[name='url']" ) ).sendKeys( "risevision.com" );
+        // remove focus
+        element( by.css( "h3.modal-title" ) ).click();
+
+        expect( element( by.css( "#pageUrl input[name='url']" ) ).getAttribute( "value" ) ).to.eventually.equal( "https://risevision.com" );
       } );
 
       it( "Should correctly save settings", function() {

--- a/test/integration/logging.html
+++ b/test/integration/logging.html
@@ -27,6 +27,7 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
 
 <script src="../../src/components/widget-common/dist/config.js"></script>
+<script src="../../src/components/widget-common/dist/common.js"></script>
 <script src="../../src/widget/webpage.js"></script>
 <script src="../../src/components/widget-common/dist/message.js"></script>
 
@@ -46,18 +47,16 @@
       params = {
         "url": window.gadget.settings.additionalParams.url,
         "company_id": '"companyId"',
-        "display_id": '"displayId"'
+        "display_id": '"displayId"',
+        "widget_id": null
       };
 
     suiteTeardown(function() {
       spy.restore();
     });
 
-    setup(function() {
-    });
-
     suite("configuration", function() {
-      test("should log the play event", function() {
+      test("should log the configuration event", function() {
         params.event = "configuration";
         params.event_details = JSON.stringify( window.gadget.settings.additionalParams );
         assert(spy.calledOnce);

--- a/test/integration/messaging.html
+++ b/test/integration/messaging.html
@@ -27,6 +27,7 @@
 <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
 
 <script src="../../src/components/widget-common/dist/config.js"></script>
+<script src="../../src/components/widget-common/dist/common.js"></script>
 <script src="../../src/widget/webpage.js"></script>
 <script src="../../src/components/widget-common/dist/message.js"></script>
 


### PR DESCRIPTION
## Description
Consolidated changes from PRs #119 and #120 

## Motivation and Context

- Stop propagating use of HTTP in urls as we only support HTTPS
- Help provide additional data to identify a presentation that is using web page widget and configured for an HTTP url

## How Has This Been Tested?
Staged version of widget, see other PRs for links/validation

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
