### PR TITLE
Prevent processing logs to client-side-events

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "angular-bootstrap": "^0.13.0",
     "jquery": "~3.3.1",
     "rv-common-style": "https://github.com/Rise-Vision/common-style.git#1.3.57",
-    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.13.0",
+    "widget-common": "https://github.com/Rise-Vision/widget-common.git#v3.14.0",
     "widget-settings-ui-components": "https://github.com/Rise-Vision/widget-settings-ui-components.git#3.4.1",
     "widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git#0.4.3",
     "common-header": "https://github.com/Rise-Vision/common-header.git#v3.3.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9187,12 +9187,6 @@
         "pinkie-promise": "2.0.1"
       }
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -12693,11 +12687,11 @@
       "requires": {
         "async": "0.9.2",
         "casperjs": "1.1.4",
-        "chai": "4.2.0",
+        "chai": "4.3.4",
         "chai-as-promised": "7.1.1",
         "event-stream": "4.0.1",
         "express": "4.17.1",
-        "glob": "7.1.6",
+        "glob": "7.1.7",
         "gulp": "3.9.1",
         "gulp-coveralls": "0.1.4",
         "gulp-html-replace": "1.6.2",
@@ -12717,7 +12711,7 @@
         "karma-phantomjs-launcher": "1.0.4",
         "karma-sinon-chai": "2.0.2",
         "karma-webpack": "1.8.1",
-        "lodash": "4.17.20",
+        "lodash": "4.17.21",
         "mocha": "6.2.2",
         "mocha-multi": "1.1.3",
         "mocha-proshot": "1.0.1",
@@ -12726,7 +12720,7 @@
         "reporter-file": "0.0.1",
         "run-sequence": "0.3.7",
         "sinon": "7.5.0",
-        "sinon-chai": "3.5.0",
+        "sinon-chai": "3.6.0",
         "spawn-cmd": "0.0.2",
         "spec-xunit-file": "0.0.1-3",
         "xml2js": "0.4.23",
@@ -12833,16 +12827,16 @@
           "dev": true
         },
         "chai": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-          "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+          "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
           "dev": true,
           "requires": {
             "assertion-error": "1.1.0",
             "check-error": "1.0.2",
             "deep-eql": "3.0.1",
             "get-func-name": "2.0.0",
-            "pathval": "1.1.0",
+            "pathval": "1.1.1",
             "type-detect": "4.0.8"
           }
         },
@@ -13035,9 +13029,9 @@
           }
         },
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -13118,7 +13112,7 @@
             "di": "0.0.1",
             "dom-serialize": "2.2.1",
             "expand-braces": "0.1.2",
-            "glob": "7.1.6",
+            "glob": "7.1.7",
             "graceful-fs": "4.2.3",
             "http-proxy": "1.18.1",
             "isbinaryfile": "3.0.3",
@@ -13155,9 +13149,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "log-symbols": {
@@ -13362,6 +13356,12 @@
             "wordwrap": "0.0.3"
           }
         },
+        "pathval": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+          "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+          "dev": true
+        },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -13415,9 +13415,9 @@
           }
         },
         "sinon-chai": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
-          "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.6.0.tgz",
+          "integrity": "sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==",
           "dev": true
         },
         "socket.io": {


### PR DESCRIPTION
## Description
Prevent the flow of processing sending logs to client-side-events project by using latest widget-common. See https://github.com/Rise-Vision/common-template/pull/203 for changes. 

## Motivation and Context
https://github.com/Rise-Vision/widget-common/issues/168

## How Has This Been Tested?
Tested using Charles Proxy to map to local version of common-template and config-prod and ran a schedule on ChrOS player. Validated no logs to `Display_Events.events` were inserted. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
